### PR TITLE
QCamera2: HAL: Check feature mask for thumbnail reprocess

### DIFF
--- a/camera/QCamera2/HAL/QCameraChannel.cpp
+++ b/camera/QCamera2/HAL/QCameraChannel.cpp
@@ -934,8 +934,12 @@ int32_t QCameraReprocessChannel::addReprocStreamsFromSource(
                 if (!param.needThumbnailReprocess(&feature_mask)) {
                     continue;
                 }
-                //Don't do WNR for thumbnail
-                feature_mask &= ~CAM_QCOM_FEATURE_DENOISE2D;
+                // CAC, SHARPNESS, FLIP and WNR would have been already applied -
+                // on preview/postview stream in realtime. Need not apply again.
+                feature_mask &= ~(CAM_QCOM_FEATURE_DENOISE2D |
+                        CAM_QCOM_FEATURE_CAC |
+                        CAM_QCOM_FEATURE_SHARPNESS |
+                        CAM_QCOM_FEATURE_FLIP);
                 if (!feature_mask) {
                     // Skip thumbnail stream reprocessing since no other
                     //reprocessing is enabled.


### PR DESCRIPTION
Issue :
Reprocess for thumbnail is triggered even though
feature mask is zero. So, Config stream is failing.

Fix :
Unmask all the features which are already applied
on online streams(preview/postview).
And then check feature mask for triggering thumbnail
reprocess

Change-Id: I189f558e5a00b4fae4987410296f7d40e1e216f5