### PR TITLE
crackling: Explicitly set RIL vendor library path

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -8,6 +8,7 @@ persist.audio.fluence.speaker=false
 ro.sf.lcd_density=320
 
 # Radio
+rild.libpath=/system/vendor/lib64/libril-qc-qmi-1.so
 ro.telephony.default_network=9,9
 persist.radio.multisim.config=dsds
 persist.radio.custom_ecc=1


### PR DESCRIPTION
Change-Id: Ie910fdbef84eae8c3434e3b80fbb52691f327e51